### PR TITLE
removed unneeded mutible references

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ where
     }
 
     /// Returns the maximum
-    pub fn get_max_duty(&mut self) -> PWM::Duty {
+    pub fn get_max_duty(&self) -> PWM::Duty {
         self.pwm.get_max_duty()
     }
 
@@ -143,7 +143,7 @@ where
     }
 
     /// Get the actual motor speed
-    pub fn get_current_duty(&mut self) -> PWM::Duty {
+    pub fn get_current_duty(&self) -> PWM::Duty {
         self.pwm.get_duty()
     }
 }


### PR DESCRIPTION
As the current mutible references stand, it is not possible to do something like this.

```rust
let mut motor = l298n::Motor::new(in_1, in_2, pwm);
motor.set_duty(motor.get_max_duty()/2);
```

you will get these error messages.
```
error[E0499]: cannot borrow `motor` as mutable more than once at a time
  --> src/main.rs:50:20
   |
50 |     motor.set_duty(motor.get_max_duty()/2);
   |     ----- -------- ^^^^^ second mutable borrow occurs here
   |     |     |
   |     |     first borrow later used by call
   |     first mutable borrow occurs here

error: aborting due to previous error; 1 warning emitted

For more information about this error, try `rustc --explain E0499`.
error: could not compile `implementation`

To learn more, run the command again with --verbose.
```

This pull requests allows for the previously stated use case.